### PR TITLE
A couple of bug fixes and logging

### DIFF
--- a/telepath/tests/test_telepath.py
+++ b/telepath/tests/test_telepath.py
@@ -8,11 +8,14 @@ test_telepath
 Tests for `telepath` module.
 """
 
+import argparse
 import unittest
 
 from telepath import telepath
 
+import mock
 from six.moves import configparser
+
 
 GOOD_CONFIGURATION_OPTIONS = {
     'endpoint': 'http://goodstandupendpoint.com',
@@ -49,6 +52,22 @@ class TestTelepath(unittest.TestCase):
         config.remove_option('telepath', 'irc_nick')
         is_config_good, reason = telepath.validate_configuration(config)
         self.assertFalse(is_config_good, reason)
+
+    def test_missing_status_file_returns_empty_status(self):
+        mo = mock.mock_open()
+        mo.side_effect = IOError("File does not exist!")
+        with mock.patch('{}.open'.format(__name__), mo, create=True):
+            return_value = telepath.get_completed_tasks("status_filename.txt")
+            self.assertEqual('', return_value)
+
+    @mock.patch.object(telepath, 'post_data_to_endpoint')
+    @mock.patch.object(telepath, 'get_completed_tasks')
+    def test_send_report_wont_send_empty_report(self,
+                                                get_completed_mock,
+                                                post_mock):
+        get_completed_mock.return_value = ''
+        telepath.send_report(argparse.Namespace(), self.good_config)
+        self.assertTrue(post_mock.call_count == 0)
 
     def tearDown(self):
         pass

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+mock==1.0.1
 hacking>=0.9.2,<0.10
 coverage>=3.6
 discover


### PR DESCRIPTION
Now telepath uses the built-in logging module instead of just printing to
stdout.
Fix an error when the status file is missing.
Adds a couple of tests around missing status files and empty task
reports.
